### PR TITLE
Add database and Playwright support

### DIFF
--- a/cosme-x/src/api.js
+++ b/cosme-x/src/api.js
@@ -1,4 +1,4 @@
 import axios from "axios";
 export const api = axios.create({
-  baseURL: "http://localhost:8000", // 后端API地址
+  baseURL: "http://localhost:8888", // 后端API地址
 });

--- a/cosme-x/src/components/LeftSection.vue
+++ b/cosme-x/src/components/LeftSection.vue
@@ -88,7 +88,7 @@ export default {
     },
     methods: {
         initWebSocket() {
-            this.socket = new WebSocket('ws://localhost:8000/ws');
+            this.socket = new WebSocket('ws://localhost:8888/ws');
             this.socket.onmessage = (event) => {
                 let data = JSON.parse(event.data);
                 if (data.type === 'prizeInfo') {

--- a/cosme-x/src/components/RightSection.vue
+++ b/cosme-x/src/components/RightSection.vue
@@ -65,7 +65,7 @@ export default {
     methods: {
         initWebSocket() {
             if (!this.socket) {
-                this.socket = new WebSocket('ws://localhost:8000/ws');
+                this.socket = new WebSocket('ws://localhost:8888/ws');
 
                 this.socket.addEventListener('open', (event) => {
                     console.log('WebSocket connection opened:', event);

--- a/cosme-y/README.md
+++ b/cosme-y/README.md
@@ -1,0 +1,28 @@
+# cosme-y Backend
+
+基于 **FastAPI** 的轻量级后端，提供前端所需的 REST API 与 WebSocket 服务。
+
+## 技术栈
+
+- Python 3.11+
+- FastAPI
+- Uvicorn
+- SQLAlchemy (SQLite)
+- Playwright
+
+## 快速开始
+
+1. (可选) 创建并激活虚拟环境： `python -m venv venv && source venv/bin/activate`
+2. 安装依赖： `pip install -r requirements.txt`
+3. 启动开发服务器：
+   ```bash
+   uvicorn main:app --reload --host 0.0.0.0 --port 8888
+   ```
+4. 前端将通过 `http://localhost:8888` 与此后端交互，并通过 `ws://localhost:8888/ws` 建立 WebSocket 连接。
+
+## 可用接口
+
+- `GET /prizes`：返回简单的奖品列表。
+- `GET /get-chromedriver-version`：尝试获取 `chromedriver` 版本。
+- `GET /page-title?url=`：使用 Playwright 获取指定页面标题。
+- `WebSocket /ws`：简单的回显示例，可根据需求扩展。

--- a/cosme-y/database.py
+++ b/cosme-y/database.py
@@ -1,0 +1,20 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+DATABASE_URL = "sqlite:///./cosme.db"
+
+engine = create_engine(
+    DATABASE_URL,
+    connect_args={"check_same_thread": False}
+)
+
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/cosme-y/main.py
+++ b/cosme-y/main.py
@@ -1,0 +1,52 @@
+from fastapi import FastAPI, WebSocket, Depends, Query
+from fastapi.responses import JSONResponse
+from sqlalchemy.orm import Session
+import subprocess
+
+from . import database, models, playwright_helper
+
+app = FastAPI(title="Cosme API")
+
+
+@app.on_event("startup")
+def on_startup():
+    # Create tables if they don't exist
+    database.Base.metadata.create_all(bind=database.engine)
+
+@app.get("/prizes")
+def list_prizes(db: Session = Depends(database.get_db)):
+    prizes = db.query(models.Prize).all()
+    # 如果数据库为空，返回示例数据
+    if not prizes:
+        prizes = [models.Prize(id=1, text="奖品A"), models.Prize(id=2, text="奖品B")]
+    return JSONResponse(content=[{"id": p.id, "text": p.text} for p in prizes])
+
+@app.websocket("/ws")
+async def websocket_endpoint(ws: WebSocket):
+    await ws.accept()
+    try:
+        while True:
+            data = await ws.receive_json()
+            await ws.send_json({"echo": data})
+    except Exception:
+        await ws.close()
+
+@app.get("/get-chromedriver-version")
+async def get_chromedriver_version():
+    try:
+        result = subprocess.run(
+            ["chromedriver", "--version"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        version = result.stdout.strip()
+    except Exception as exc:
+        version = str(exc)
+    return {"chromedriver_version": version}
+
+
+@app.get("/page-title")
+async def page_title(url: str = Query(..., description="要抓取的页面URL")):
+    title = await playwright_helper.fetch_title(url)
+    return {"title": title}

--- a/cosme-y/models.py
+++ b/cosme-y/models.py
@@ -1,0 +1,8 @@
+from sqlalchemy import Column, Integer, String
+from .database import Base
+
+class Prize(Base):
+    __tablename__ = "prizes"
+
+    id = Column(Integer, primary_key=True, index=True)
+    text = Column(String, nullable=False)

--- a/cosme-y/playwright_helper.py
+++ b/cosme-y/playwright_helper.py
@@ -1,0 +1,10 @@
+from playwright.async_api import async_playwright
+
+async def fetch_title(url: str) -> str:
+    async with async_playwright() as p:
+        browser = await p.chromium.launch()
+        page = await browser.new_page()
+        await page.goto(url)
+        title = await page.title()
+        await browser.close()
+        return title

--- a/cosme-y/requirements.txt
+++ b/cosme-y/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+SQLAlchemy
+playwright

--- a/cosme-y/start.sh
+++ b/cosme-y/start.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+uvicorn main:app --reload --host 0.0.0.0 --port 8888


### PR DESCRIPTION
## Summary
- update frontend API and websocket ports to 8888
- extend backend with SQLAlchemy and Playwright helpers
- add database models and helper functions
- document new dependencies and usage in backend README

## Testing
- `python3 -m py_compile cosme-y/main.py cosme-y/database.py cosme-y/models.py cosme-y/playwright_helper.py`
- `pip install -r cosme-y/requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_68846391599c8326af8e3c29ade60ea0